### PR TITLE
VercelでホストしているAPIへの差し替え

### DIFF
--- a/.env.dummy
+++ b/.env.dummy
@@ -1,1 +1,1 @@
-VITE_RESAS_API_KEY=YOUR_API_KEY
+VITE_VERCEL_URL=https://hogehoge.vercel.app

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ node_modules
 /.cache
 /build
 /public/build
-.env
+.env.*
 
 *storybook.log

--- a/app/utils/axiosClient.ts
+++ b/app/utils/axiosClient.ts
@@ -1,10 +1,7 @@
 import axios from "axios";
 
 const client = axios.create({
-	baseURL: "https://opendata.resas-portal.go.jp/api/v1/",
-	headers: {
-		"X-API-KEY": import.meta.env.VITE_RESAS_API_KEY,
-	},
+	baseURL: import.meta.env.VITE_VERCEL_URL,
 });
 
 export default client;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
 	"sideEffects": false,
 	"type": "module",
 	"scripts": {
-		"build": "remix vite:build",
-		"dev": "remix vite:dev",
+		"build": "remix vite:build --mode prod",
+		"dev": "remix vite:dev --mode dev",
 		"lint": "eslint --ignore-path .gitignore --cache --cache-location ./node_modules/.cache/eslint .",
 		"preview": "vite preview",
 		"typecheck": "tsc",


### PR DESCRIPTION
# 概要
RESAS APIを直接叩きに行っていた処理を，vercelでホストしているserverless functions経由で実施するように変更した．

## 背景
RESAS APIを直接叩くと，API KEYがクライアントに見えてしまうため．
プロキシサーバーとして vercel serverless functionsを導入することによりクライアントからAPI KEYが見えないようにする．

# 変更点
- vercelでホストしているエンドポイントに**API KEYなし**で通信するように変更

# 注意点
以降の作業はバックエンドが立ち上がっている必要がある(prod環境はgithub pagesからのリクエストのみ受け付けるようになっているため，`localhost:5173`からの通信を許可した開発用バックエンドが必要)