### PR TITLE
都道府県ごとに人口構成を取得する変更

### DIFF
--- a/app/api/resasApi.ts
+++ b/app/api/resasApi.ts
@@ -20,7 +20,6 @@ export const fetchPrefectures = async (): Promise<Prefecture[]> => {
 
 export const fetchPopulationComposition = async ({
 	prefCode,
-	addArea,
 }: FetchPopulationOptions): Promise<PopulationCompositionResponse> => {
 	try {
 		const response = await axiosClient.get<
@@ -28,7 +27,6 @@ export const fetchPopulationComposition = async ({
 		>("/population/composition/perYear", {
 			params: {
 				prefCode,
-				addArea,
 			},
 		});
 		return response.data.result;

--- a/app/types/resas.d.ts
+++ b/app/types/resas.d.ts
@@ -31,5 +31,4 @@ export interface ResasResponse<T> {
 }
 export interface FetchPopulationOptions {
 	prefCode: string;
-	addArea?: string; // "1_,13_" や "1_01100,13_13101" などの形式で複数エリアを指定
 }


### PR DESCRIPTION
# 概要
チェックした都道府県**それぞれ**の人口構成をAPI経由で取得するように変更

## 背景
チェックした都道府県の人口構成を合計したデータを取得していたため．

# 変更点
- チェックした都道府県ごとにAPIをcallするように変更
- APIのパラメータから`addArea`を削除した