### PR TITLE
人口構成グラフの作成と導入

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -8,6 +8,11 @@ import { fetchPopulationComposition, fetchPrefectures } from "~/api/resasApi";
 import Button from "~/src/ui/Button";
 import Card from "~/src/ui/Card";
 import Checkbox from "~/src/ui/Checkbox";
+import PopulationChart from "~/src/views/PopulationChart";
+import {
+	PopulationCategory,
+	transformPopulationData,
+} from "~/utils/transform-population-data";
 
 export const clientLoader = async ({ request }: ClientLoaderFunctionArgs) => {
 	const prefectures = await fetchPrefectures();
@@ -34,6 +39,11 @@ export default function Index() {
 	const getPrefNameByIndex = (index: number) => {
 		return prefectures.at(index)?.prefName;
 	};
+
+	const transformedData = transformPopulationData(
+		prefCodes,
+		populationData || [],
+	);
 	return (
 		<>
 			<Form method="get">
@@ -66,28 +76,12 @@ export default function Index() {
 			</Form>
 
 			<h2 className="mt-6 text-4xl">人口推移グラフ</h2>
-			<Card className="p-3">
-				{populationData?.map((data, index) => (
-					<div key={data.boundaryYear}>
-						<h3 className="text-2xl">
-							{getPrefNameByIndex(index)} - {data.data[0].label}
-						</h3>
-						{data.data.map((population) => (
-							<>
-								<p key={population.label}>{population.label}</p>
-								<div key={population.label}>
-									{population.data.map((datum) => (
-										<div key={datum.year}>
-											<p>
-												{datum.year}年: {datum.value}人
-											</p>
-										</div>
-									))}
-								</div>
-							</>
-						))}
-					</div>
-				))}
+			<Card className="p-3 mt-4 h-96">
+				<PopulationChart
+					data={transformedData[PopulationCategory.TotalPopulation]}
+					xKey={"year"}
+					lineKeys={prefCodes}
+				/>{" "}
 			</Card>
 		</>
 	);

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -40,6 +40,14 @@ export default function Index() {
 		return prefectures.at(index)?.prefName;
 	};
 
+	const getPrefNameByCode = (prefCode: string) => {
+		console.log(prefCode);
+		return (
+			prefectures.find((pref) => Number(pref.prefCode) === Number(prefCode))
+				?.prefName || prefCode
+		);
+	};
+
 	const transformedData = transformPopulationData(
 		prefCodes,
 		populationData || [],
@@ -76,11 +84,12 @@ export default function Index() {
 			</Form>
 
 			<h2 className="mt-6 text-4xl">人口推移グラフ</h2>
-			<Card className="p-3 mt-4 h-96">
+			<Card className="p-4 mt-4 h-96">
 				<PopulationChart
 					data={transformedData[PopulationCategory.TotalPopulation]}
 					xKey={"year"}
 					lineKeys={prefCodes}
+					legendFormatter={getPrefNameByCode}
 				/>{" "}
 			</Card>
 		</>

--- a/app/src/views/PopulationChart/PopulationChart.stories.tsx
+++ b/app/src/views/PopulationChart/PopulationChart.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import PopulationChart from "./";
+import { data } from "./constant";
+
+const meta: Meta<typeof PopulationChart> = {
+	component: PopulationChart,
+	title: "app/src/view/PopulationChart",
+};
+
+export default meta;
+type Story = StoryObj<typeof PopulationChart>;
+
+/*
+ *👇 Render functions are a framework specific feature to allow you control on how the component renders.
+ * See https://storybook.js.org/docs/api/csf
+ * to learn how to use render functions.
+ */
+export const Default: Story = {
+	render: () => (
+		<div style={{ height: "300px" }}>
+			<PopulationChart data={data} xKey={"name"} lineKeys={["uv"]} />
+		</div>
+	),
+};

--- a/app/src/views/PopulationChart/constant.ts
+++ b/app/src/views/PopulationChart/constant.ts
@@ -1,0 +1,44 @@
+export const data = [
+	{
+		name: "Page A",
+		uv: 4000,
+		pv: 2400,
+		amt: 2400,
+	},
+	{
+		name: "Page B",
+		uv: 3000,
+		pv: 1398,
+		amt: 2210,
+	},
+	{
+		name: "Page C",
+		uv: 2000,
+		pv: 9800,
+		amt: 2290,
+	},
+	{
+		name: "Page D",
+		uv: 2780,
+		pv: 3908,
+		amt: 2000,
+	},
+	{
+		name: "Page E",
+		uv: 1890,
+		pv: 4800,
+		amt: 2181,
+	},
+	{
+		name: "Page F",
+		uv: 2390,
+		pv: 3800,
+		amt: 2500,
+	},
+	{
+		name: "Page G",
+		uv: 3490,
+		pv: 4300,
+		amt: 2100,
+	},
+];

--- a/app/src/views/PopulationChart/index.tsx
+++ b/app/src/views/PopulationChart/index.tsx
@@ -1,0 +1,55 @@
+import {
+	CartesianGrid,
+	Legend,
+	Line,
+	LineChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+
+export interface PopulationChartProps<T> {
+	data: T[];
+	xKey: keyof T;
+	lineKeys: Array<keyof T>;
+}
+
+const PopulationChart = <T,>({
+	data,
+	xKey,
+	lineKeys,
+}: PopulationChartProps<T>) => {
+	return (
+		<ResponsiveContainer width="100%" height="100%">
+			<LineChart
+				data={data}
+				width={500}
+				height={300}
+				margin={{
+					top: 5,
+					right: 30,
+					left: 20,
+					bottom: 5,
+				}}
+			>
+				<CartesianGrid strokeDasharray="3 3" />
+				<XAxis dataKey={String(xKey)} />
+				<YAxis />
+				<Tooltip />
+				<Legend />
+				{lineKeys.map((key, index) => (
+					<Line
+						key={String(key)}
+						type="monotone"
+						dataKey={String(key)}
+						stroke={index % 2 === 0 ? "#8884d8" : "#82ca9d"}
+						activeDot={{ r: 8 }}
+					/>
+				))}
+			</LineChart>
+		</ResponsiveContainer>
+	);
+};
+
+export default PopulationChart;

--- a/app/src/views/PopulationChart/index.tsx
+++ b/app/src/views/PopulationChart/index.tsx
@@ -1,5 +1,7 @@
+import { useState } from "react";
 import {
 	CartesianGrid,
+	Label,
 	Legend,
 	Line,
 	LineChart,
@@ -13,13 +15,32 @@ export interface PopulationChartProps<T> {
 	data: T[];
 	xKey: keyof T;
 	lineKeys: Array<keyof T>;
+	legendFormatter?: (value: string) => string;
 }
 
 const PopulationChart = <T,>({
 	data,
 	xKey,
 	lineKeys,
+	legendFormatter = (value) => value,
 }: PopulationChartProps<T>) => {
+	const [stroke, setStroke] = useState<{ [key: string]: number }>({
+		...Object.fromEntries(lineKeys.map((key) => [String(key), 1])),
+	});
+
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	const handleMouseEnter = (o: any) => {
+		const { dataKey } = o;
+
+		setStroke((op) => ({ ...op, [dataKey]: 4 }));
+	};
+
+	// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+	const handleMouseLeave = (o: any) => {
+		const { dataKey } = o;
+
+		setStroke((op) => ({ ...op, [dataKey]: 2 }));
+	};
 	return (
 		<ResponsiveContainer width="100%" height="100%">
 			<LineChart
@@ -27,17 +48,27 @@ const PopulationChart = <T,>({
 				width={500}
 				height={300}
 				margin={{
-					top: 5,
-					right: 30,
+					top: 40,
 					left: 20,
-					bottom: 5,
+					bottom: 15,
 				}}
 			>
 				<CartesianGrid strokeDasharray="3 3" />
-				<XAxis dataKey={String(xKey)} />
-				<YAxis />
+				<XAxis dataKey={String(xKey)}>
+					<Label value="年次" offset={-10} position="insideBottom" />
+				</XAxis>
+				<YAxis>
+					<Label value="人口" position="top" offset={20} />
+				</YAxis>
 				<Tooltip />
-				<Legend />
+				<Legend
+					layout="vertical"
+					align="right"
+					verticalAlign="middle"
+					formatter={legendFormatter}
+					onMouseEnter={handleMouseEnter}
+					onMouseLeave={handleMouseLeave}
+				/>
 				{lineKeys.map((key, index) => (
 					<Line
 						key={String(key)}
@@ -45,6 +76,7 @@ const PopulationChart = <T,>({
 						dataKey={String(key)}
 						stroke={index % 2 === 0 ? "#8884d8" : "#82ca9d"}
 						activeDot={{ r: 8 }}
+						strokeWidth={stroke[String(key)]}
 					/>
 				))}
 			</LineChart>

--- a/app/utils/transform-population-data/index.test.ts
+++ b/app/utils/transform-population-data/index.test.ts
@@ -1,0 +1,152 @@
+import type { PopulationComposition } from "~/types/resas";
+import { PopulationCategory, transformPopulationData } from "./";
+
+describe("transformPopulationData", () => {
+	it("should transform population data correctly", () => {
+		const prefectureCodes = ["01", "02", "03"];
+		const data: { boundaryYear: number; data: PopulationComposition[] }[] = [
+			{
+				boundaryYear: 2020,
+				data: [
+					{
+						label: "総人口",
+						data: [
+							{ year: 2020, value: 1000 },
+							{ year: 2021, value: 2000 },
+							{ year: 2022, value: 3000 },
+						],
+					},
+					{
+						label: "年少人口",
+						data: [
+							{ year: 2020, value: 1000 },
+							{ year: 2021, value: 2000 },
+							{ year: 2022, value: 3000 },
+						],
+					},
+					{
+						label: "生産年齢人口",
+						data: [
+							{ year: 2020, value: 1000 },
+							{ year: 2021, value: 2000 },
+							{ year: 2022, value: 3000 },
+						],
+					},
+					{
+						label: "老年人口",
+						data: [
+							{ year: 2020, value: 1000 },
+							{ year: 2021, value: 2000 },
+							{ year: 2022, value: 3000 },
+						],
+					},
+				],
+			},
+			{
+				boundaryYear: 2021,
+				data: [
+					{
+						label: "総人口",
+						data: [
+							{ year: 2020, value: 4000 },
+							{ year: 2021, value: 5000 },
+							{ year: 2022, value: 6000 },
+						],
+					},
+					{
+						label: "年少人口",
+						data: [
+							{ year: 2020, value: 4000 },
+							{ year: 2021, value: 5000 },
+							{ year: 2022, value: 6000 },
+						],
+					},
+					{
+						label: "生産年齢人口",
+						data: [
+							{ year: 2020, value: 4000 },
+							{ year: 2021, value: 5000 },
+							{ year: 2022, value: 6000 },
+						],
+					},
+					{
+						label: "老年人口",
+						data: [
+							{ year: 2020, value: 4000 },
+							{ year: 2021, value: 5000 },
+							{ year: 2022, value: 6000 },
+						],
+					},
+				],
+			},
+			{
+				boundaryYear: 2022,
+				data: [
+					{
+						label: "総人口",
+						data: [
+							{ year: 2020, value: 7000 },
+							{ year: 2021, value: 8000 },
+							{ year: 2022, value: 9000 },
+						],
+					},
+					{
+						label: "年少人口",
+						data: [
+							{ year: 2020, value: 7000 },
+							{ year: 2021, value: 8000 },
+							{ year: 2022, value: 9000 },
+						],
+					},
+					{
+						label: "生産年齢人口",
+						data: [
+							{ year: 2020, value: 7000 },
+							{ year: 2021, value: 8000 },
+							{ year: 2022, value: 9000 },
+						],
+					},
+					{
+						label: "老年人口",
+						data: [
+							{ year: 2020, value: 7000 },
+							{ year: 2021, value: 8000 },
+							{ year: 2022, value: 9000 },
+						],
+					},
+				],
+			},
+		];
+
+		const transformedData = transformPopulationData(prefectureCodes, data);
+
+		// keys of transformedData should be PopulationCategory
+		expect(Object.keys(transformedData)).toEqual(
+			Object.values(PopulationCategory),
+		);
+
+		expect(transformedData[PopulationCategory.TotalPopulation]).toEqual([
+			{ year: 2020, "01": 1000, "02": 4000, "03": 7000 },
+			{ year: 2021, "01": 2000, "02": 5000, "03": 8000 },
+			{ year: 2022, "01": 3000, "02": 6000, "03": 9000 },
+		]);
+
+		expect(transformedData[PopulationCategory.YoungPopulation]).toEqual([
+			{ year: 2020, "01": 1000, "02": 4000, "03": 7000 },
+			{ year: 2021, "01": 2000, "02": 5000, "03": 8000 },
+			{ year: 2022, "01": 3000, "02": 6000, "03": 9000 },
+		]);
+
+		expect(transformedData[PopulationCategory.WorkingAgePopulation]).toEqual([
+			{ year: 2020, "01": 1000, "02": 4000, "03": 7000 },
+			{ year: 2021, "01": 2000, "02": 5000, "03": 8000 },
+			{ year: 2022, "01": 3000, "02": 6000, "03": 9000 },
+		]);
+
+		expect(transformedData[PopulationCategory.ElderlyPopulation]).toEqual([
+			{ year: 2020, "01": 1000, "02": 4000, "03": 7000 },
+			{ year: 2021, "01": 2000, "02": 5000, "03": 8000 },
+			{ year: 2022, "01": 3000, "02": 6000, "03": 9000 },
+		]);
+	});
+});

--- a/app/utils/transform-population-data/index.ts
+++ b/app/utils/transform-population-data/index.ts
@@ -1,0 +1,55 @@
+import type { PopulationComposition } from "~/types/resas";
+
+export enum PopulationCategory {
+	TotalPopulation = "総人口",
+	YoungPopulation = "年少人口",
+	WorkingAgePopulation = "生産年齢人口",
+	ElderlyPopulation = "老年人口",
+}
+
+interface YearlyData {
+	year: number;
+	[prefCode: string]: number;
+}
+
+export type TransformedData = {
+	[key in PopulationCategory]: YearlyData[];
+};
+
+export function transformPopulationData(
+	prefectureCodes: string[],
+	data: { boundaryYear: number; data: PopulationComposition[] }[],
+): TransformedData {
+	const result: TransformedData = {
+		[PopulationCategory.TotalPopulation]: [],
+		[PopulationCategory.YoungPopulation]: [],
+		[PopulationCategory.WorkingAgePopulation]: [],
+		[PopulationCategory.ElderlyPopulation]: [],
+	};
+
+	for (const [index, prefectureData] of data.entries()) {
+		const prefCode = prefectureCodes[index];
+
+		for (let i = 0; i < prefectureData.data.length; i++) {
+			const category = Object.values(PopulationCategory)[i];
+
+			for (const { year, value } of prefectureData.data[i].data) {
+				// 該当カテゴリと年次データの項目を探すか、無ければ新規作成
+				let yearData = result[category].find((data) => data.year === year);
+				if (!yearData) {
+					yearData = { year };
+					result[category].push(yearData);
+				}
+				// 都道府県コードをキーに値を追加
+				yearData[prefCode] = value;
+			}
+		}
+	}
+
+	// 各カテゴリごとの年次データを昇順に並べる
+	for (const key of Object.keys(result) as Array<PopulationCategory>) {
+		result[key].sort((a, b) => a.year - b.year);
+	}
+
+	return result;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
 				"axios": "^1.7.7",
 				"isbot": "^4",
 				"react": "^18.2.0",
-				"react-dom": "^18.2.0"
+				"react-dom": "^18.2.0",
+				"recharts": "^2.13.3"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "1.9.4",
@@ -495,7 +496,6 @@
 			"version": "7.26.0",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
 			"integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -3747,6 +3747,60 @@
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
 			"integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
 		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+			"integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+		},
+		"node_modules/@types/d3-interpolate": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+			"dependencies": {
+				"@types/d3-color": "*"
+			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-P2dlU/q51fkOc/Gfl3Ul9kicV7l+ra934qBFXCFhrZMOL6du1TM0pm1ThYvENukyOn5h9v+yMJ9Fn5JK4QozrQ=="
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.8.tgz",
+			"integrity": "sha512-gkK1VVTr5iNiYJ7vWDI+yUFFlszhNMtVeneJ6lUTKPjprsvLLI9/tgEGiXJOnlINJA8FyA88gfnQsHbybVZrYQ==",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.6.tgz",
+			"integrity": "sha512-5KKk5aKGu2I+O6SONMYSNflgiP0WfZIQvVUMan50wHsLG1G94JlxEVnCpQARfTtzytuY0p/9PXXZb3I7giofIA==",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
+			"integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+		},
 		"node_modules/@types/debug": {
 			"version": "4.1.12",
 			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -5668,6 +5722,14 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5900,8 +5962,117 @@
 		"node_modules/csstype": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"dev": true
+			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+			"integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/damerau-levenshtein": {
 			"version": "1.0.8",
@@ -6009,6 +6180,11 @@
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
 			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
 			"dev": true
+		},
+		"node_modules/decimal.js-light": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
 		},
 		"node_modules/decode-named-character-reference": {
 			"version": "1.0.2",
@@ -6216,6 +6392,15 @@
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
 			"dev": true
+		},
+		"node_modules/dom-helpers": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+			"integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+			"dependencies": {
+				"@babel/runtime": "^7.8.7",
+				"csstype": "^3.0.2"
+			}
 		},
 		"node_modules/dot-prop": {
 			"version": "9.0.0",
@@ -7475,6 +7660,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/eventemitter3": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -7616,6 +7806,14 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true
+		},
+		"node_modules/fast-equals": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.0.1.tgz",
+			"integrity": "sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==",
+			"engines": {
+				"node": ">=6.0.0"
+			}
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.2",
@@ -8885,6 +9083,14 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -10059,8 +10265,7 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"node_modules/lodash.camelcase": {
 			"version": "4.3.0",
@@ -11524,7 +11729,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -12510,7 +12714,6 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -12787,8 +12990,7 @@
 		"node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"node_modules/react-refresh": {
 			"version": "0.14.2",
@@ -12827,6 +13029,35 @@
 			"peerDependencies": {
 				"react": ">=16.8",
 				"react-dom": ">=16.8"
+			}
+		},
+		"node_modules/react-smooth": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.1.tgz",
+			"integrity": "sha512-OE4hm7XqR0jNOq3Qmk9mFLyd6p2+j6bvbPJ7qlB7+oo0eNcL2l7WQzG6MBnT3EXY6xzkLMUBec3AfewJdA0J8w==",
+			"dependencies": {
+				"fast-equals": "^5.0.1",
+				"prop-types": "^15.8.1",
+				"react-transition-group": "^4.4.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/react-transition-group": {
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+			"integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+			"dependencies": {
+				"@babel/runtime": "^7.5.5",
+				"dom-helpers": "^5.0.1",
+				"loose-envify": "^1.4.0",
+				"prop-types": "^15.6.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.6.0",
+				"react-dom": ">=16.6.0"
 			}
 		},
 		"node_modules/read-cache": {
@@ -12889,6 +13120,41 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/recharts": {
+			"version": "2.13.3",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-2.13.3.tgz",
+			"integrity": "sha512-YDZ9dOfK9t3ycwxgKbrnDlRC4BHdjlY73fet3a0C1+qGMjXVZe6+VXmpOIIhzkje5MMEL8AN4hLIe4AMskBzlA==",
+			"dependencies": {
+				"clsx": "^2.0.0",
+				"eventemitter3": "^4.0.1",
+				"lodash": "^4.17.21",
+				"react-is": "^18.3.1",
+				"react-smooth": "^4.0.0",
+				"recharts-scale": "^0.4.4",
+				"tiny-invariant": "^1.3.1",
+				"victory-vendor": "^36.6.8"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
+		"node_modules/recharts-scale": {
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+			"integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+			"dependencies": {
+				"decimal.js-light": "^2.4.1"
+			}
+		},
+		"node_modules/recharts/node_modules/react-is": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+			"integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+		},
 		"node_modules/redent": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12938,8 +13204,7 @@
 		"node_modules/regenerator-runtime": {
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-			"dev": true
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.3",
@@ -14787,8 +15052,7 @@
 		"node_modules/tiny-invariant": {
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-			"dev": true
+			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -15590,6 +15854,27 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/victory-vendor": {
+			"version": "36.9.2",
+			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+			"integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+			"dependencies": {
+				"@types/d3-array": "^3.0.3",
+				"@types/d3-ease": "^3.0.0",
+				"@types/d3-interpolate": "^3.0.1",
+				"@types/d3-scale": "^4.0.2",
+				"@types/d3-shape": "^3.1.0",
+				"@types/d3-time": "^3.0.0",
+				"@types/d3-timer": "^3.0.0",
+				"d3-array": "^3.1.6",
+				"d3-ease": "^3.0.1",
+				"d3-interpolate": "^3.0.1",
+				"d3-scale": "^4.0.2",
+				"d3-shape": "^3.1.0",
+				"d3-time": "^3.0.0",
+				"d3-timer": "^3.0.1"
 			}
 		},
 		"node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"axios": "^1.7.7",
 		"isbot": "^4",
 		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
+		"react-dom": "^18.2.0",
+		"recharts": "^2.13.3"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",


### PR DESCRIPTION
# 概要
選択肢た都道府県の人口を表示する折れ線グラフコンポーネントを作成し，配置した．

# 理由
ユーザーが人口の推移を把握するには，生データよりグラフで可視化した方が直感的で理解が用意になるから．

# 変更点
- 人口推移折れ線グラフコンポーネントを作成した
- 取得した都道府県別人口推移データを整形するメソッドを作成した

# 留意点
パッケージの更新をお願いします

# 確認事項
- ユニットテストがパスすることを確認した
- チェックした都道府県の人口推移が折れ線グラフでそれぞれ描画されることをブラウザテストで確認した

# 未実施事項(グラフ領域)
- グラフのツールチップをリッチにする
　- 都道府県コードを都道府県名に変更する
- ✅ 人口種別(総人口，年少人口など)の切り替えセレクトを実装する
　- 総人口を固定で表示しているため，セレクトコンポーネントで切り替え可能にする
- 縦軸(人口)の表示を見やすくする
　- ,区切りのあるフォーマットにしてユーザが読みやすいようにする