### PR TITLE
表示するカテゴリ変更機能の実装

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -4,11 +4,13 @@ import {
 	useLoaderData,
 	useSearchParams,
 } from "@remix-run/react";
+import { useState } from "react";
 import { fetchPopulationComposition, fetchPrefectures } from "~/api/resasApi";
 import Button from "~/src/ui/Button";
 import Card from "~/src/ui/Card";
 import Checkbox from "~/src/ui/Checkbox";
 import PopulationChart from "~/src/views/PopulationChart";
+import Select from "~/src/views/Select";
 import {
 	PopulationCategory,
 	transformPopulationData,
@@ -36,8 +38,12 @@ export default function Index() {
 	const [searchParams] = useSearchParams();
 	const prefCodes = searchParams.getAll("prefCode");
 
-	const getPrefNameByIndex = (index: number) => {
-		return prefectures.at(index)?.prefName;
+	const [selectedCategory, setSelectedCategory] = useState<PopulationCategory>(
+		PopulationCategory.TotalPopulation,
+	);
+
+	const handleCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+		setSelectedCategory(e.target.value as PopulationCategory);
 	};
 
 	const getPrefNameByCode = (prefCode: string) => {
@@ -83,10 +89,16 @@ export default function Index() {
 				</div>
 			</Form>
 
-			<h2 className="mt-6 text-4xl">人口推移グラフ</h2>
+			<div className="flex items-center mt-6 gap-4">
+				<h2 className="text-4xl">人口推移グラフ</h2>
+				<div className="flex items-center gap-2">
+					<h3 className="text-lg">表示カテゴリ: </h3>
+					<Select value={selectedCategory} onChange={handleCategoryChange} />
+				</div>
+			</div>
 			<Card className="p-4 mt-4 h-96">
 				<PopulationChart
-					data={transformedData[PopulationCategory.TotalPopulation]}
+					data={transformedData[selectedCategory]}
 					xKey={"year"}
 					lineKeys={prefCodes}
 					legendFormatter={getPrefNameByCode}

--- a/app/src/views/Select/Select.stories.tsx
+++ b/app/src/views/Select/Select.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { type ChangeEventHandler, useState } from "react";
+import Select from ".";
+
+const meta: Meta<typeof Select> = {
+	component: Select,
+	title: "app/src/view/Select",
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+const Template = (args: React.ComponentProps<typeof Select>) => {
+	const [value, setValue] = useState<string>("");
+	const onChange: ChangeEventHandler<HTMLSelectElement> = (event) => {
+		setValue(event.target.value);
+	};
+	return <Select {...args} value={value} onChange={onChange} />;
+};
+
+export const Default: Story = {
+	render: (args) => <Template {...args} />,
+	args: {
+		// Selectコンポーネントに渡すデフォルトの引数（必要に応じて追加）
+	},
+};

--- a/app/src/views/Select/Select.test.tsx
+++ b/app/src/views/Select/Select.test.tsx
@@ -1,0 +1,61 @@
+// Select.test.tsx
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PopulationCategory } from "~/utils/transform-population-data";
+import Select from "./";
+
+describe("Select component", () => {
+	it("renders all options from PopulationCategory", () => {
+		render(
+			<Select value={PopulationCategory.TotalPopulation} onChange={() => {}} />,
+		);
+
+		// Check that each option in PopulationCategory is rendered
+		for (const category of Object.values(PopulationCategory)) {
+			expect(
+				screen.getByRole("option", { name: category }),
+			).toBeInTheDocument();
+		}
+	});
+
+	it("displays the correct selected value", () => {
+		const selectedValue = PopulationCategory.TotalPopulation;
+		render(<Select value={selectedValue} onChange={() => {}} />);
+
+		// Check that the select element has the correct selected value
+		expect(screen.getByRole("combobox")).toHaveValue(selectedValue);
+	});
+
+	it("calls onChange when a different option is selected", () => {
+		const handleChange = vi.fn();
+		render(
+			<Select
+				value={PopulationCategory.TotalPopulation}
+				onChange={handleChange}
+			/>,
+		);
+
+		// Change the selected value
+		fireEvent.change(screen.getByRole("combobox"), {
+			target: { value: PopulationCategory.WorkingAgePopulation },
+		});
+
+		// Verify that onChange is called with the new value
+		expect(handleChange).toHaveBeenCalledTimes(1);
+		expect(handleChange).toHaveBeenCalledWith(expect.any(Object)); // Confirm the event object is passed
+	});
+
+	it("applies the provided className", () => {
+		const customClass = "custom-select-class";
+		render(
+			<Select
+				value={PopulationCategory.TotalPopulation}
+				onChange={() => {}}
+				className={customClass}
+			/>,
+		);
+
+		// Check that the custom class name is applied
+		expect(screen.getByRole("combobox")).toHaveClass(customClass);
+	});
+});

--- a/app/src/views/Select/index.tsx
+++ b/app/src/views/Select/index.tsx
@@ -1,0 +1,35 @@
+import { PopulationCategory } from "~/utils/transform-population-data";
+
+const Select: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = ({
+	value,
+	onChange,
+	className,
+}) => {
+	return (
+		<select
+			className={`
+				p-4
+				bg-gradient-to-r 
+				from-black/40 
+				via-white/40 to-transparent 
+				bg-[#E7EBF0] 
+				bg-blend-soft-light 
+				shadow-[inset_-2.5px_-2.5px_5px_#FAFBFF,inset_2.5px_2.5px_5px_#A6ABBD] 
+				rounded-[10px] 
+				border-[#CED1DC]
+				border-1
+				appearance-none
+				${className}
+			`}
+			value={value}
+			onChange={onChange}
+		>
+			{Object.values(PopulationCategory).map((category) => (
+				<option key={category} value={category}>
+					{category}
+				</option>
+			))}
+		</select>
+	);
+};
+export default Select;


### PR DESCRIPTION
# 概要
総人口，年少人口，生産年齢人口，老年人口から表示カテゴリを変更できる機能を実装しました．

# 変更点
- カテゴリを選択できるSelectコンポーネントを実装
- Select コンポーネントの反映

# テスト
- Selectコンポーネントのユニットテストがパスすることを確認
- Selectコンポーネントでカテゴリを切り替えたらグラフのデータが変化することをブラウザテストにて確認